### PR TITLE
Fix: using winston-mail breaks global underscore templating

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -12,9 +12,12 @@ var winston = require('winston');
 var _       = require('underscore');
 
 // Set Underscore to Mustache style templates
-_.templateSettings = {
-  interpolate : /\{\{(.+?)\}\}/g
-};
+
+function template(text, obj) {
+  return _.template(text,obj, {
+    interpolate : /\{\{(.+?)\}\}/g
+  });
+}
 
 /**
  * @constructs Mail
@@ -33,7 +36,7 @@ var Mail = exports.Mail = function (options) {
   this.from       = options.from                   || "winston@" + os.hostname()
   this.level      = options.level                  || 'info';
   this.silent     = options.silent                 || false;
-  this.subject    = options.subject ? _.template(options.subject) : _.template("winston: {{level}} {{msg}}")
+  this.subject    = options.subject ? template(options.subject) : template("winston: {{level}} {{msg}}")
 
   this.handleExceptions = options.handleExceptions || false;
   this.server  = email.server.connect({


### PR DESCRIPTION
At the top of winston-mail.js, the change to _.templateSettings has global effects for apps using underscore.

If an app uses winston mail and also expect to do EJS-style underscore templating, those apps get broken because the _.templateSettings.evaluate field gets removed.

winston-mail should make this change locally, this fix does that.  

Tests passed.
