### PR TITLE
Allow only single line messages in the subject.

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -79,7 +79,7 @@ Mail.prototype.log = function (level, msg, meta, callback) {
   var message = email.message.create({
     from: this.from,
     to: this.to,
-    subject: this.subject({level: level, msg: msg}),
+    subject: this.subject({level: level, msg: msg.split('\n')[0]}),
     text: body
   });
 


### PR DESCRIPTION
Messages with newlines work with the default transports, but break mail headers in this one. {{msg}} in the subject could instead be thought of as a preview of the first line in the case of multi-line messages.

This is how ThunderBird displays a multi-line subject line.
![Capture](https://f.cloud.github.com/assets/48617/149991/e643ce72-7540-11e2-80c7-9708b2855dcd.PNG)
