### PR TITLE
Empty meta info was added into the email body

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -71,10 +71,11 @@ Mail.prototype.log = function (level, msg, meta, callback) {
   var self = this;
   if (this.silent) return callback(null, true);
 
-  if (meta) // add some pretty printing
-    meta = util.inspect(meta, null, 5)
+  var body = msg;
 
-  var body = meta ? msg + "\n\n" + meta : msg;
+  // add meta info into the body if not empty
+  if (meta !== null && meta !== undefined && (typeof meta !== 'object' || Object.keys(meta).length > 0))
+      body += "\n\n" + util.inspect(meta, {depth: 5}); // add some pretty printing
 
   var message = email.message.create({
     from: this.from,


### PR DESCRIPTION
Meta object is now excluded from the email body in case the object does not have any properties (e.g. is empty).
Previously, if the object was empty, the email body contained "{}" string at the end of body.
