### PR TITLE
Throwing Error instance rather than String

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -28,15 +28,15 @@ var Mail = exports.Mail = function (options) {
   options = options || {};
 
   if (!options.to){
-    throw "winston-mail requires 'to' property";
+    throw new Error("winston-mail requires 'to' property");
   }
 
   this.name       = 'mail';
   this.to         = options.to;
-  this.from       = options.from                   || "winston@" + os.hostname()
+  this.from       = options.from                   || "winston@" + os.hostname();
   this.level      = options.level                  || 'info';
   this.silent     = options.silent                 || false;
-  this.subject    = options.subject ? template(options.subject) : template("winston: {{level}} {{msg}}")
+  this.subject    = options.subject ? template(options.subject) : template("winston: {{level}} {{msg}}");
 
   this.handleExceptions = options.handleExceptions || false;
   this.server  = email.server.connect({


### PR DESCRIPTION
By throwing the `Error` instance rather than the string it means that `error.stack` will be available to aid debugging. For example, when using [`grunt-mocha-test`](https://github.com/pghalliday/grunt-mocha-test/blob/0.11.0/tasks/mocha-test.js#L80).

Plus added in a couple of missing semi-colons :smile: 
