### PR TITLE
allow override of name

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -31,7 +31,7 @@ var Mail = exports.Mail = function (options) {
     throw new Error("winston-mail requires 'to' property");
   }
 
-  this.name       = 'mail';
+  this.name       = options.name                   || 'mail';
   this.to         = options.to;
   this.from       = options.from                   || "winston@" + os.hostname();
   this.level      = options.level                  || 'info';


### PR DESCRIPTION
I'd like to send multiple log levels through the Mail Transport but it looks like I can't add more than one.

See https://github.com/flatiron/winston/pull/187
