### PR TITLE
[feature] enable boolean to log only the selected level and none above

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -35,6 +35,7 @@ var Mail = exports.Mail = function (options) {
   this.to         = options.to;
   this.from       = options.from                   || "winston@" + os.hostname();
   this.level      = options.level                  || 'info';
+  this.unique     = options.unique                 || false;
   this.silent     = options.silent                 || false;
   this.subject    = options.subject ? template(options.subject) : template("winston: {{level}} {{msg}}");
   this.html       = options.html                   || false; //Send mail in html format
@@ -71,6 +72,7 @@ winston.transports.Mail = Mail;
 Mail.prototype.log = function (level, msg, meta, callback) {
   var self = this;
   if (this.silent) return callback(null, true);
+  if (this.unique && this.level != level) return callback(null, true);
 
   var body = msg;
 

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ The Mail transport uses [emailjs](https://github.com/eleith/emailjs) behind the 
 * __ssl:__ Use SSL (boolean or object { key, ca, cert })
 * __tls:__ Boolean (if true, use starttls)
 * __level:__ Level of messages that this transport should log.
+* __unique:__ Boolean flag indicating whether to log only the declared level and none above.
 * __silent:__ Boolean flag indicating whether to suppress output.
 * __html:__ Boolean flag indicating whether to send mail body as html attach.
 


### PR DESCRIPTION
Hi,
I needed to log only one log level and not all the levels above it so I made some minor changes in order to enable a boolean flag that indicates whether to log only the declared level.

It might be useful to others so I made this pull request, hope it helps.
Best,
Jaime