### PR TITLE
Upgrading version of emailjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "email"
   ],
   "dependencies": {
-    "emailjs": "1.0.0",
+    "emailjs": "1.0.5",
     "underscore": "1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
emailjs 1.0.0 depends on a vulnerable version of momentjs (https://github.com/molant/winston-mail.git). Version 1.0.5 fixes that