### PR TITLE
Update import statement on README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ var winston = require('winston');
  * Requiring `winston-mail` will expose
  * `winston.transports.Mail`
  */
-require('winston-mail').Mail;
+require('winston-mail');
 
 winston.add(winston.transports.Mail, options);
 ```


### PR DESCRIPTION
Simply `require('winston-mail');` should work for exposing Mail transport.
`require('winston-mail').Mail;` would break an eslint rule `no-unused-expressions`.


