### PR TITLE
Adjust the number of defined arguments to match Winston 3+

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -70,7 +70,7 @@ winston.transports.Mail = Mail
  * @param arg3 winston < 3 {function} Continuation to respond to when complete.
                winston >= 3 undefined
  */
-Mail.prototype.log = function(arg0, arg1, arg2, arg3) {
+Mail.prototype.log = function(arg0, arg1) {
   // get winston version to create tests accordingly
   var winstonVersion = winston.version,
       majorWVersion = winstonVersion.split('.')[0],
@@ -89,8 +89,8 @@ Mail.prototype.log = function(arg0, arg1, arg2, arg3) {
   } else {
       level = arg0;
       msg = arg1;
-      meta = arg2;
-      callback = arg3;
+      meta = arguments[2];
+      callback = arguments[3];
   }
 
   if (this.silent) return callback(null, true)


### PR DESCRIPTION
Winston 3.0+ uses the [length of the `log` function](https://github.com/winstonjs/winston/blob/664b44ba4d8656880c1d09253eabc55636ab97ef/lib/winston/logger.js#L336) to determine whether the transport is legacy or not. In Winston 3+, the existence of `arg2` and `arg3` in the function definition results in Winston 3+'s core treating the transport as a legacy transport (which the function is _not_ set up for).

The solution is to remove the arguments from the function definition and rely on the `arguments` array to access them in legacy mode. See [this comment](https://github.com/wavded/winston-mail/issues/48#issuecomment-433471452) for more.

**NOTE:** This change assumes that the function passes the _other_ check that Winston 3+ makes to determine whethr or not to run in legacy mode:

>They inherit from `winston.Transport` in  < 3.x.x which is NOT a stream.

This should help address #48.