### PR TITLE
Use original info object in v3

### DIFF
--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -92,7 +92,7 @@ Mail.prototype.log = function(arg0, arg1) {
     meta = arguments[2];
     callback = arguments[3];
     info = {
-      level,
+      level: level,
       message: msg,
       meta: meta,
     };

--- a/lib/winston-mail.js
+++ b/lib/winston-mail.js
@@ -76,29 +76,34 @@ Mail.prototype.log = function(arg0, arg1) {
       majorWVersion = winstonVersion.split('.')[0],
       self = this;
 
-  var callback, level, msg, meta;
+  var callback, level, msg, meta, info;
 
   if (majorWVersion >= 3 ) {
     // in version above 3 we have only 2 parameters: info and callback;
-    var info = arg0;
-    
+    info = arg0;
+
     callback = arg1;
     level = info.level;
     msg = info.message || '';
     meta = info.meta;
   } else {
-      level = arg0;
-      msg = arg1;
-      meta = arguments[2];
-      callback = arguments[3];
+    level = arg0;
+    msg = arg1;
+    meta = arguments[2];
+    callback = arguments[3];
+    info = {
+      level,
+      message: msg,
+      meta: meta,
+    };
   }
 
   if (this.silent) return callback(null, true)
   if (this.unique && this.level != level) return callback(null, true)
-  if (this.filter && !this.filter({level: level, message: msg, meta: meta})) return callback(null, true)
+  if (this.filter && !this.filter(info)) return callback(null, true)
 
   if (this.formatter) {
-    body = this.formatter({level: level, message: msg, meta: meta})
+    var body = this.formatter(info)
   } else {
     var body = msg
 


### PR DESCRIPTION
By recreating another object with only a subset of the original properties, one cannot leverage the winston filters. Fix this by passing directly the info object